### PR TITLE
Explicit permission escalation is now needed for a push

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v1.1.0
         with:
@@ -46,6 +48,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v1.1.0
         with:


### PR DESCRIPTION
Basically you now must denote that you want the action to have write:
```
    permissions:
      contents: write
```

I have no idea where this is documented but I found it from another action.