### PR TITLE
feat: Enable doxygen version to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ jobs:
 - `folder` (optional): Folder where the docs are built. Defaults to `docs/html`.
 - `config_file` (optional): Path of the Doxygen configuration file. Defaults to `Doxyfile`.
 - `target_folder` (optional): Directory within the deployment branch to push to. Defaults to empty (root).
+- `doxygen_version` (optional): Version of Doxygen to install. Defaults to `1.9.6`. **NOTE - only works with 1.9.3 and higher versions**
 
 ## Advanced Usage
 
@@ -54,6 +55,7 @@ jobs:
           branch: gh-pages
           folder: docs/html
           config_file: Doxyfile
+          doxygen_version: 1.9.6
 ```
 
 ## About this Action

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   target_folder:
     description: 'Directory on the deployment branch for pushing the build files'
     required: false
+  doxygen_version:
+    description: 'Version of Doxygen to install'
+    required: false
+    default: "1.9.6"
 
 runs:
   using: "composite"
@@ -33,8 +37,16 @@ runs:
       with:
         submodules: "true"
 
-    - name: Install Doxygen
-      run: sudo apt-get install doxygen graphviz -y
+    - name: Install dependencies
+      run: sudo apt-get update && sudo apt-get install -y wget graphviz
+      shell: bash
+
+    - name: Install Doxygen v${{ inputs.doxygen_version }}
+      run: |
+        transformed_version=$(echo "${{ inputs.doxygen_version }}" | tr '.' '_')
+        wget https://github.com/doxygen/doxygen/releases/download/Release_${transformed_version}/doxygen-${{ inputs.doxygen_version }}.linux.bin.tar.gz
+        tar -xzf doxygen-${{ inputs.doxygen_version }}.linux.bin.tar.gz
+        sudo mv doxygen-${{ inputs.doxygen_version }}/bin/doxygen /usr/local/bin/doxygen
       shell: bash
 
     - name: Generate Doxygen Documentation


### PR DESCRIPTION
This makes the version of doxygen a paramter and allows the installation of versions that might not be available via `apt-get`.

Closes #29 