### PR TITLE
Update the sample in README.md with explicit permission control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write 
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
         with:
@@ -48,6 +51,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write 
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
         with:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pages: write 
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
         with:
@@ -53,7 +52,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pages: write 
     steps:
       - uses: DenverCoder1/doxygen-github-pages-action@v2.0.0
         with:


### PR DESCRIPTION
By adding the explicit permission declaration, the user can deploy the HTML document with the default workflow permission of their repository.
```yaml
    permissions:
      contents: write
      pages: write
```

In issue #24, It is suggested to change the Workflow permission of the user repository setting from "Read repository contents and packages permissions" (default) to "Read and write permissions", to avoid the error at deployment by GitHub actions (See the figure below). 

![2024-09-25 (2)](https://github.com/user-attachments/assets/2965dc31-40aa-421a-9f92-d2dd54d20743)

This explicit permission declaration in this pull request has two advantages compared to the one suggested in Issue #24.

1. The user of doxygen-github-pages-action doesn't need to change the repository workflow permission from the default ( easy to use ). 
2. The user can keep the repository workflow permission in a strict state ( global safe ). 

The changed YAMLs inside README.md have been tested with my test repository. I confirmed they work fine.  

- [Simple sample YAML](https://github.com/suikan4github/sandbox-actions/actions/runs/11027366192)
- [Advanced sample YAML](https://github.com/suikan4github/sandbox-actions/actions/runs/11027397669)